### PR TITLE
Allow base scenario as scenario instance

### DIFF
--- a/tests/test_roadway.py
+++ b/tests/test_roadway.py
@@ -511,6 +511,7 @@ def test_add_adhoc_field_from_card(request):
     )
     print("--Finished:", request.node.name)
 
+
 @pytest.mark.roadway
 @pytest.mark.travis
 def test_bad_properties_statements(request):
@@ -1156,7 +1157,6 @@ def test_find_segment(request):
     print(seg_df)
 
 
-@pytest.mark.menow
 @pytest.mark.roadway
 @pytest.mark.travis
 def test_managed_lane_restricted_access_egress(request):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -57,6 +57,22 @@ def test_project_card_write(request):
 
 @pytest.mark.scenario
 @pytest.mark.travis
+def test_scenario_initialization(request):
+    print("\n--Starting:", request.node.name)
+    card_dir = os.path.join(STPAUL_DIR, "project_cards")
+    card_file = os.path.join(card_dir, "1_simple_roadway_attribute_change.yml")
+
+    project_card = ProjectCard.read(card_file)
+
+    # test initialization using both dict and Scenario instance
+    scenario_A = Scenario({}, [project_card])
+    scenario_B = Scenario(scenario_A, [])
+
+    print("--Finished:", request.node.name)
+
+
+@pytest.mark.scenario
+@pytest.mark.travis
 def test_scenario_conflicts(request):
 
     project_cards_list = []


### PR DESCRIPTION
Closes #298 to allow base scenario be a scenario instance.

Also includes various updates/fixes to typehints/docstrings in `scenario.py` and PEP8 updates.

Tested via: `test_scenario_initialization()`