### PR TITLE
Governance Docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people  
+* Being respectful of differing opinions, viewpoints, and experiences  
+* Giving and gracefully accepting constructive feedback  
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience  
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+The community leaders for this effort include project Leadership and the Product Management Team as described in the [Project Governance](CONTRIBUTING.md#project-governance).
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [`tidestransit@gmail.com`](mailto:tidestransit@gmail.com).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to Network Wrangler
+
+Thank you for your interest in contributing to the Network Wrangler Project.  This document defines the roles and process for contributing to the project and documents the governance roles and approach for decision-making.
+
+## Roles
+
+There are two types of contributors to Network Wrangler:
+
+* Registered Contributors can create and respond to issues and can generate and comment on pull requests; 
+* All other Stakeholders can create and respond to issues.
+
+All contributors and stakeholders are asked to adhere to the [Code of Conduct](#code-of-conduct).
+
+To become a Registered Contributor, please send an [email to Sijia Wang](mailto:sijia.wang@wsp.com).
+
+## How to Contribute
+
+Contributions should be offered through GitHub issues and pull requests.
+
+By making any contribution to the projects, contributors self-certify to the [Contributor Agreement](#contributor-agreement).
+
+### Setup
+
+1. Make sure you have a [GitHub](https://github.com/) account.  
+2. Make sure you have [git](https://git-scm.com/downloads), a terminal (e.g. Mac Terminal, CygWin, etc.), and a text editor installed on your local machine.  Optionally, you will likely find it easier to use [GitHub Desktop](https://desktop.github.com/), an IDE instead of a simple text editor like [VSCode](https://code.visualstudio.com/), [Eclipse](https://www.eclipse.org/), [Sublime Text](https://www.sublimetext.com/), etc.  
+3. [Fork the repository](https://github.com/wsp-sag/network_wrangler/fork) into your own GitHub account and [clone it locally](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).  
+4. [Create a branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) to work on a new issue (or checkout an existing one where the issue is being worked on).  
+5. Install [pre-commit](https://pre-commit.com/) so you can check your code and text formatting.  
+
+### Issues
+
+Create issues to start discussion on a new topic.  If the issue is associated with a pull request, be sure to link the two.  There are shortcuts [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+
+### Pull Requests
+
+Use the following guidance in creating and responding to pull requests
+
+* Keep pull requests small and focused. One issue is best.
+* Link Pull Requests to Issues as appropriate.
+* Complete the pull request template as best you can.
+
+### Commits
+
+Use the following guidance for commits
+
+* Provide a short, clear title.  Capitalize. No period at the end.
+* Wrap the body of text at 72 characters
+
+## Contributor Agreement
+
+By making any contribution to the projects, contributors self-certify to the following Contributor Agreement:
+
+By making a contribution to this project, I certify that:
+>  
+> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+>  
+> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+>  
+> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+>  
+> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+>  
+Attribution: This Contributor Agreement is adapted from the node.js project available [here](https://github.com/nodejs/node/blob/main/CONTRIBUTING.md).
+
+## License to Use
+
+Network Wrangler is licensed under the Apache License 2.0 as defined in <LICENSE> file.
+
+## Project Governance
+
+The governance for Network Wrangler is, for now, limited and lightweight. The governance approach will be periodically revisited.
+
+Development of Network Wrangler shall be managed by the following groups:
+
+* [Leadership Group](#leadership-group)
+* [Product Management Team](#product-management-team)
+* [Registered Contributors](#registered-contributors)
+* [All Other Stakeholders](#stakeholders-group)
+
+These groups will have the following rights and responsibilities:
+
+### Leadership Group
+
+The Leadership Group is responsible for overall direction and decision-making on the project including:
+
+* approval of registered contributors;
+* creation, scoping, and management of working groups and the product management team; and,
+* approval of changes to project governance.
+
+Leadership Group Members
+
+* Jonathan Ehlrich, Met Council (Minneapolis, MN)
+* Lisa Zorn, Metropolitan Transportation Commission (San Francisco, CA)
+* David Ory, WSP
+
+Leadership Group Member [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Admin
+
+### Product Management Team
+
+The Product Management Team (PMT) is responsible for creating and maintaining backbone standards infrastructure, processes, and resources to support the development of Network Wrangler.  The PMT will support Leadership in developing, reviewing, and recommending for approval, changes to the code base.  The PMT will support Contributors and Stakeholders in their work on the specification.  
+
+PMT Group Members
+
+* Elizabeth Sall, UrbanLabs LLC
+* Sijia Wang, WSP
+
+
+PMT Group Member [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Admin
+
+### Registered Contributors
+
+Registered Contributors actively work to develop Network Wrangler. They propose additions, modifications, and improvements to the speciation document through issues and pull requests in this GitHub repository.
+
+Registered Contributors must request to be registered in order to gain access by [emailing Sijia Wang](mailto:sijia.wang@wsp.com).  Requests to become a Contributor must be approved by project Leadership.
+
+Registered Contributor Group Members:
+
+The list of registered contributors is maintained in the [contributors.md](contributors.md) file.
+
+Registered Contributor Group [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Write
+
+
+## Review and Approval Process
+
+Prior to release of a Network Wrangler version, the PMT and Leadership will have final approval of all changes.   All Contributors are permitted and encouraged to discuss and comment on issues and pull requests and make recommendations for changes to the specification.
+
+## Code of Conduct
+
+Contributors to the Network Wrangler Project are expected to read and follow the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) for the project.

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,1 @@
+# Contributors


### PR DESCRIPTION
@lmz, @JonathanEhrlichMC 

In an effort to nudge the governance of Network Wrangler forward a bit and, possibly, to prepare to move the repository to a different org (either [network-wrangler](https://github.com/network-wrangler) or [MetCouncil](https://github.com/Metropolitan-Council)), I've taking a first pass at some governance documents, building from @e-lo's experience with the [TIDES project](https://github.com/TIDES-transit/TIDES). 

Please have a look and comment, edit, suggest as appropriate.   

fyi @i-am-sijia 