### PR TITLE
Allow kwargs in network creation to override Class-level variables for Roadway and Transit

### DIFF
--- a/examples/single/link_diffIDs.json
+++ b/examples/single/link_diffIDs.json
@@ -1,0 +1,72 @@
+[
+  {
+    "different_link_id": 224,
+    "osm_link_id": "18214905,18220565",
+    "shape_id": "9ef30f714e972087771ed705654fd1f5",
+    "A": 3230,
+    "B": 52771,
+    "roadway": "residential",
+    "name": "B Street",
+    "lanes": 1,
+    "distance": 0.0503218951,
+    "locationReferences": [
+      {
+        "sequence": 1,
+        "point": [
+          -93.0837695,
+          44.963344
+        ],
+        "distanceToNextRef": 80.9850385918,
+        "bearing": 0,
+        "intersectionId": "4d0231aa0ebb779f142c2518703ee481"
+      },
+      {
+        "sequence": 2,
+        "point": [
+          -93.0832419,
+          44.9629432
+        ],
+        "intersectionId": "3654951b676940911fe5021b93c90cc5"
+      }
+    ]
+  },
+  {
+    "different_link_id": 381163,
+    "osm_link_id": "49696191",
+    "shape_id": "7b426b583a223dab32e02207bbe7df15",
+    "A": 3494,
+    "B": 121739,
+    "roadway": "motorway",
+    "name": "A Street",
+    "lanes": 5,
+    "distance": 0.0350601947,
+    "HOV_access": 0,
+    "trn_priority": 0,
+    "ttime_assert": 0,
+    "transit_access": 0,
+    "drive_access": 1,
+    "walk_access": 0,
+    "bike_access": 0,
+    "transit_walk_access": 0,
+    "locationReferences": [
+      {
+        "sequence": 1,
+        "point": [
+          -93.0965985,
+          44.9521122
+        ],
+        "distanceToNextRef": 56.4237737799,
+        "bearing": 0,
+        "intersectionId": "0751f5ce12472360fed0d0e80ceae35c"
+      },
+      {
+        "sequence": 2,
+        "point": [
+          -93.0960047,
+          44.9523954
+        ],
+        "intersectionId": "5c9e5e0f2e6d67208f848f22a6d03700"
+      }
+    ]
+  }
+]

--- a/network_wrangler/__init__.py
+++ b/network_wrangler/__init__.py
@@ -13,7 +13,7 @@ from .utils import point_df_to_geojson, link_df_to_json, make_slug
 from .utils import parse_time_spans, offset_location_reference, haversine_distance
 from .utils import create_unique_shape_id
 from .utils import create_location_reference_from_nodes
-from .utils import create_line_string
+from .utils import create_line_string,class_vars
 
 
 __all__ = [
@@ -33,6 +33,7 @@ __all__ = [
     "create_location_reference_from_nodes",
     "create_line_string",
     "net_to_mapbox",
+    "class_vars"
 ]
 
 setupLogging(

--- a/network_wrangler/utils.py
+++ b/network_wrangler/utils.py
@@ -8,6 +8,14 @@ from geographiclib.geodesic import Geodesic
 
 from .logger import WranglerLogger
 
+def class_vars(my_class)->list:
+    """Returns a list of variables in a class
+
+    Args:
+        my_class: class to get variables for
+    """
+    return [attr for attr in dir(my_class) if not callable(getattr(my_class, attr)) and not attr.startswith("__")]
+
 
 def point_df_to_geojson(df: pd.DataFrame, properties: list):
     """

--- a/tests/test_roadway.py
+++ b/tests/test_roadway.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from network_wrangler import RoadwayNetwork
 from network_wrangler import ProjectCard
+from network_wrangler import WranglerLogger
 import time
 import pandas as pd
 
@@ -1155,8 +1156,6 @@ def test_find_segment(request):
     seg_df = net.identify_segment(seg_ends[0], seg_ends[1], selection_dict=sel_dict)
     print(seg_df)
 
-
-@pytest.mark.menow
 @pytest.mark.roadway
 @pytest.mark.travis
 def test_managed_lane_restricted_access_egress(request):
@@ -1244,3 +1243,24 @@ def test_managed_lane_restricted_access_egress(request):
         \n***GP Links\n{gp_links[_display_c]}"
 
     print("--Finished:", request.node.name)
+
+@pytest.mark.menow
+def test_kwarg_instantiation(request):
+    WranglerLogger.info(f"--Starting: {request.node.name}")
+
+    update_values = {
+        'unique_link_key':'different_link_id'
+    }
+
+    net = RoadwayNetwork.read(
+        link_file=SMALL_LINK_FILE,
+        node_file=SMALL_NODE_FILE,
+        shape_file=SMALL_SHAPE_FILE,
+        fast=True,
+        **update_values
+    )
+
+    WranglerLogger.debug(f"RoadwayNetwork.UNIQUE_LINK_KEY: {RoadwayNetwork.UNIQUE_LINK_KEY}")
+    assert RoadwayNetwork.UNIQUE_LINK_KEY == update_values['unique_link_key']
+
+    WranglerLogger.info(f"--Finished: {request.node.name}")


### PR DESCRIPTION
This PR adds steps to the `read()` function for both RoadwayNetwork and TransitNetwork which will read in kwargs from the `read()` variables and will update any matching (upper-case) class-level variables to the specified values.

This is useful for when an agency might need to use a different unique ID or variable set from the defaults. 

Also:
- added util method: `class_vars()`
- test network links which use different Key than `model_link_id`

Tested via: `test_kwarg_instantiation()`

Closes Issue #290 