### PR TITLE
Fix broken transit shapes due to roadway changes

### DIFF
--- a/network_wrangler/projectcard.py
+++ b/network_wrangler/projectcard.py
@@ -112,7 +112,7 @@ class ProjectCard(object):
             _yaml, _pycode = cardfile.read().split(delim)
             WranglerLogger.debug("_yaml: {}\n_pycode: {}".format(_yaml, _pycode))
 
-        attribute_dictionary = yaml.load(_yaml)
+        attribute_dictionary = yaml.safe_load(_yaml)
         attribute_dictionary["file"] = w_card_filename
         attribute_dictionary["pycode"] = _pycode.lstrip("\n")
 

--- a/network_wrangler/roadwaynetwork.py
+++ b/network_wrangler/roadwaynetwork.py
@@ -1664,6 +1664,17 @@ class RoadwayNetwork(object):
                 if key not in df_column_names:
                     new_row_to_add[key] = new_dict[key]
 
+            for unique_link_id in self.unique_link_ids:
+                if unique_link_id in df_column_names:
+
+                    if new_row_to_add[unique_link_id] in df[unique_link_id] or new_row_to_add[unique_link_id]==0 or type(new_row_to_add[unique_link_id])==str or new_row_to_add[unique_link_id] is None:
+                        new_row_to_add[unique_link_id] = df[unique_link_id].max()+1
+
+            for unique_node_id in self.unique_node_ids:
+                if unique_node_id in df_column_names:
+                    if new_row_to_add[unique_node_id] in df[unique_node_id] or new_row_to_add[unique_node_id]==0 or type(new_row_to_add[unique_node_id])==str or new_row_to_add[unique_node_id] is None:
+                        new_row_to_add[unique_node_id] = df[unique_node_id].max()+1
+
             out_df = df.append(new_row_to_add, ignore_index=True)
             return out_df
 

--- a/network_wrangler/scenario.py
+++ b/network_wrangler/scenario.py
@@ -310,7 +310,7 @@ class Scenario(object):
         WranglerLogger.debug("Adding project card dependencies")
         if project_card.dependencies.get("prerequisites"):
             self.prerequisites.update(
-                {project_card.project: project_card.dependencies["prerequisites"]}
+                {project_card.project.lower(): [element.lower() for element in project_card.dependencies["prerequisites"]]}
             )
         if project_card.dependencies.get("corequisites"):
             self.corequisites.update(


### PR DESCRIPTION
Fix to issue #330 

The idea is to call the new method scenario.update_transit_net_with_new_road_net() after applying roadway project cards.
