### PR TITLE
allow setting ml access egress other than 'all'

### DIFF
--- a/network_wrangler/roadwaynetwork.py
+++ b/network_wrangler/roadwaynetwork.py
@@ -830,6 +830,9 @@ class RoadwayNetwork(object):
 
         WranglerLogger.debug("starting ox.gdfs_to_graph()")
         try:
+            if (int(ox.__version__.split('.')[0]) >= 1):
+            # index required in newer osmnx
+                graph_links = graph_links.set_index(["u", "v", "key"])
             G = ox.graph_from_gdfs(graph_nodes, graph_links)
         except AttributeError:
             WranglerLogger.debug(

--- a/network_wrangler/roadwaynetwork.py
+++ b/network_wrangler/roadwaynetwork.py
@@ -2180,9 +2180,6 @@ class RoadwayNetwork(object):
             [gp_df, ml_df.add_prefix("ML_")], axis=1, join="inner"
         )
 
-        access_set = ml_df.iloc[0]['access']
-        egress_set = ml_df.iloc[0]['egress']
-
         access_df = gp_df.iloc[0:0, :].copy()
         egress_df = gp_df.iloc[0:0, :].copy()
 
@@ -2201,6 +2198,7 @@ class RoadwayNetwork(object):
             return out_location_reference
 
         for index, row in gp_ml_links_df.iterrows():
+            access_set = row['ML_access']
             if access_set == 'all' or row['A'] in access_set:
                 access_row = {}
                 access_row["A"] = row["A"]
@@ -2229,6 +2227,7 @@ class RoadwayNetwork(object):
 
                 access_df = access_df.append(access_row, ignore_index=True)
 
+            egress_set = row['ML_egress']
             if egress_set == 'all' or row['B'] in egress_set:
                 egress_row = {}
                 egress_row["A"] = row["ML_B"]


### PR DESCRIPTION
The `create_dummy_connector_links` function in `bicounty` branch set `access_set` and `egress_set` to be the first `access/egress` attribute value from the function input dataframe `ml_df`.
Since `create_dummy_connector_links` function will only be called once when converting network from standard network to model network (instead of calling this function once for each managed project card), the first `access/egress` attribute value will apply to all managed lane links.

The `create_dummy_connector_links` function in `master` branch also do not restrict access/egress connector to only nodes specified in the `access/egress` attribute, as it loops through `gp_ml_links_df` and create access/egress links for all of them.

The changes made here was modified from the `bicounty` branch by:
- removed lines that set `access_set` and `egress_set` to be the first `access/egress` attribute value from `ml_df`
- while iterating through the rows of `gp_ml_links_df`, set `access_set` and `egress_set` to be the values stored in the `access/egress` for this specific row