### PR TITLE
Revert "assign ml node in the 950,000 range"

### DIFF
--- a/network_wrangler/roadwaynetwork.py
+++ b/network_wrangler/roadwaynetwork.py
@@ -158,8 +158,6 @@ class RoadwayNetwork(object):
     SP_WEIGHT_FACTOR = 100
     MANAGED_LANES_NODE_ID_SCALAR = 500000
     MANAGED_LANES_LINK_ID_SCALAR = 1000000
-    MANAGED_LANES_NODE_ID_MIN= 950001
-    MANAGED_LANES_NODE_ID_MAX= 1000000
 
     SELECTION_REQUIRES = ["link"]
 
@@ -2174,20 +2172,12 @@ class RoadwayNetwork(object):
             )
             return out_location_reference
 
-        # ml_links_df["A"] = (
-        #     ml_links_df["A"] + RoadwayNetwork.MANAGED_LANES_NODE_ID_SCALAR
-        # )
-        # ml_links_df["B"] = (
-        #     ml_links_df["B"] + RoadwayNetwork.MANAGED_LANES_NODE_ID_SCALAR
-        # )
-        unique_ids = pd.concat([ml_links_df['A'], ml_links_df['B']]).unique()
-        available_ids = (iter(range(RoadwayNetwork.MANAGED_LANES_NODE_ID_MIN, 
-                                    RoadwayNetwork.MANAGED_LANES_NODE_ID_MAX))
+        ml_links_df["A"] = (
+            ml_links_df["A"] + RoadwayNetwork.MANAGED_LANES_NODE_ID_SCALAR
         )
-        ml_node_mapping = {original_id: next(available_ids) for original_id in unique_ids}
-        ml_links_df["A"] = ml_links_df['A'].map(ml_node_mapping)
-        ml_links_df["B"] = ml_links_df['B'].map(ml_node_mapping)
-
+        ml_links_df["B"] = (
+            ml_links_df["B"] + RoadwayNetwork.MANAGED_LANES_NODE_ID_SCALAR
+        )
         ml_links_df[RoadwayNetwork.UNIQUE_LINK_KEY] = (
             ml_links_df[RoadwayNetwork.UNIQUE_LINK_KEY]
             + RoadwayNetwork.MANAGED_LANES_LINK_ID_SCALAR


### PR DESCRIPTION
Reverts wsp-sag/network_wrangler#338, because from Rachel: 

Bad news – the managed lane change solved one problem but created another huge one 

Our highway assignment requires mnpass_pay links, which are calculated in our notebooks based off the code that Dave wrote. However this code is dependent on the 500,000 difference between managed lane and GP 

I just fixed a bunch of issues via project card and need to rerun scenarios ASAP. 

My best guess at fixing this would be to roll back lasso and NW to version before we pushed changes for the ML node numbers, and then manually correct those nodes over 1million by hand. 

Can you confirm which version of network wrangler and lasso I should use? I don’t see a fast way to fix this code to work …. We need to keep working on this issue I guess

![image](https://github.com/wsp-sag/network_wrangler/assets/28812722/1a2f48b3-8f43-4cb6-9aa6-b6934a42b142)



 
