### PR TITLE
chore: add AI agent context files (AGENTS.md, USERS.md, conventions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Context for AI coding assistants working on network_wrangler.
+
+## Quick Start
+
+```bash
+pip install -e ".[tests]"
+pre-commit install
+pytest                           # run all tests
+pre-commit run --all-files       # lint + format + type check
+mkdocs serve                     # local docs
+```
+
+## Key Docs (read these, don't duplicate)
+
+- **Architecture & design**: `docs/design.md`
+- **Data models & schemas**: `docs/data_models.md`
+- **Coding conventions**: `docs/conventions.md`
+- **Setup & workflow**: `CONTRIBUTING.md`
+- **Users & UX context**: `USERS.md`
+- **Network data model**: `docs/networks.md`
+- **Usage guide**: `docs/how_to.md`
+
+## Ecosystem
+
+Four repos under [network-wrangler](https://github.com/network-wrangler) org:
+
+```
+Cube Files → cube_wrangler → ProjectCards (.yml)
+                                    ↓
+                           network_wrangler applies cards
+                                    ↓
+                 met_council_wrangler transforms network
+                                    ↓
+                           Cube-ready model network
+```
+
+| Repo | Role |
+|------|------|
+| [`projectcard`](https://github.com/network-wrangler/projectcard) | ProjectCard schema, validation, read/write |
+| `network_wrangler` (this repo) | Load networks, apply project cards, write output |
+| [`cube_wrangler`](https://github.com/network-wrangler/cube_wrangler) | Diff Cube model files, emit ProjectCards |
+| [`met_council_wrangler`](https://github.com/Metropolitan-Council/met_council_wrangler) | Region-specific transformations for Met Council |
+
+**Downstream impact**: changes to scoped-property logic, project handlers, or `ProjectCard`/`SubProject` interfaces affect `cube_wrangler` and `met_council_wrangler`. Check before changing public APIs.
+
+## Conventions & Testing
+
+See `docs/conventions.md` for full details on: coding style, validation strategy, pandas/pandera/geopandas patterns, scoped properties, testing, commits, and diagram maintenance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,13 @@ Cube Files → cube_wrangler → ProjectCards (.yml)
 ## Conventions & Testing
 
 See `docs/conventions.md` for full details on: coding style, validation strategy, pandas/pandera/geopandas patterns, scoped properties, testing, commits, and diagram maintenance.
+
+## Task-Specific Skills
+
+Behavioral guidance for common task types lives in `skills/` (Anthropic Agent Skill format, usable by Claude Code, Codex, and other skill-aware agents):
+
+- `skills/debugging-root-cause/` — root-cause discipline for bugs, test failures, pandera/FK errors
+- `skills/performance-work/` — measure-before-optimize workflow for regional-scale networks
+- `skills/feature-design/` — user-persona + ecosystem-impact checks before adding features
+
+Agents without skill auto-invocation can read these files directly when the task matches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md
+
+Read `AGENTS.md` for project context, conventions, ecosystem overview, and doc pointers.
+Read `USERS.md` for user personas and UX principles.
+
+## Claude-Specific Instructions
+
+- Use `pre-commit run --all-files` to validate before suggesting code is complete
+- When modifying public APIs, check downstream impact on `cube_wrangler` and `met_council_wrangler` (see ecosystem in AGENTS.md)
+- Prefer reading existing docs (`docs/design.md`, `docs/conventions.md`, `CONTRIBUTING.md`) over asking the user to re-explain project structure
+- When project cards are involved, use `from projectcard import ProjectCard, read_cards` — never reimplement card parsing
+
+## Related Repository Paths (Local)
+
+| Repo | Path |
+|------|------|
+| `projectcard` | `/Users/elizabethsall/Documents/GitHub/projectcard` |
+| `cube_wrangler` | `/Users/elizabethsall/Documents/GitHub/cube_wrangler` |
+| `met_council_wrangler` | `/Users/elizabethsall/Documents/GitHub/met_council_wrangler` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,10 @@ Leveraging these extensions to their full potential may take some configuration.
 !!! tip
     Don't forget to update any associated [documentation](#documentation) as well!
 
+## Diagram Maintenance
+
+Architecture and data flow diagrams live as mermaid blocks in `docs/design.md`. When your PR changes module relationships, class hierarchies, or data flow, update the relevant diagram in the same PR. Current diagrams cover: ecosystem data flow, core object model, roadway selection, project application flow, scoped property resolution, and IO pipeline.
+
 ## Documentation
 
 Documentation is stored in the `/docs` folder and created by [`mkdocs`](https://www.mkdocs.org/) using the [`material-for-mkdocs`](https://squidfunk.github.io/mkdocs-material/) theme.
@@ -148,7 +152,20 @@ Your code **must** pass the pre-commit tests as a part of continuous integration
 
 ### Adding Tests
 
-..to come
+Tests live in `/tests` organized by module (`test_roadway/`, `test_transit/`, `test_models/`, `test_utils/`).
+
+**Fixtures**: Use session-scoped fixtures in `tests/conftest.py` for expensive setup like loading networks. Module-specific fixtures go in subdirectory `conftest.py` files.
+
+**Markers**:
+
+- `@pytest.mark.skipci` — tests that should not run in CI (e.g., require large data or external services)
+- `@pytest.mark.failing` — known failures being investigated
+
+**Naming**: Test files match source files (`test_links.py` for `links.py`). Test functions start with `test_` and describe the behavior being tested.
+
+**Pandas compatibility**: Tests must pass on both pandas 2.x and 3.x. Use `pd.testing.assert_frame_equal()` for DataFrame comparisons. Be aware that string dtype behavior differs between versions.
+
+**Benchmarks**: Performance-critical tests go in `test_benchmarks.py` and are tracked via `pytest-benchmark` across PRs.
 
 ### Running Tests
 

--- a/USERS.md
+++ b/USERS.md
@@ -1,0 +1,43 @@
+# Users & UX Context
+
+This file helps contributors and AI coding assistants understand who uses network_wrangler and in what context. Use this when making design decisions about APIs, error messages, defaults, and feature direction.
+
+## Personas
+
+### 1. Transportation Planners (primary end users)
+
+- Non-programmers or light scripters who run scenarios via config files and project cards
+- Interact mostly through YAML project cards and CLI tools (`network_wrangler/bin/`)
+- Need clear, actionable error messages and forgiving input handling
+- Tooling context: typically use a travel demand model GUI (e.g., Cube) with network_wrangler as a preprocessing step
+
+### 2. Model Developers (power users)
+
+- Python-proficient staff at agencies (Met Council, MTC, etc.) building/extending travel demand models
+- Call the Python API directly: `load_roadway()`, `create_scenario()`, `scenario.apply_all_projects()`
+- Care about performance, type safety, and predictable behavior
+- Tooling context: Jupyter notebooks, Python scripts, CI pipelines
+
+### 3. Tool Developers (ecosystem contributors)
+
+- Build on top of network_wrangler (cube_wrangler, met_council_wrangler, regional forks)
+- Need stable public APIs, clear extension points, and well-documented Pandera schemas
+- Tooling context: developing in parallel repos that import network_wrangler
+
+### 4. CI/Automation (non-interactive)
+
+- Scripts and pipelines that run network_wrangler in batch mode for scenario building
+- Need deterministic behavior, machine-readable errors, and meaningful exit codes
+- Tooling context: GitHub Actions, regional agency build systems
+
+## UX Principles
+
+When making implementation decisions, consider:
+
+- **Error messages** should be actionable and reference the specific project card, data file, or field that caused the issue. Include what was expected vs. what was found.
+- **Defaults** should work for the common case (single-region, standard GTFS, reasonable performance settings).
+- **Breaking API changes** affect tool developers and CI — require deprecation warnings and a migration path.
+- **CLI interface** (`network_wrangler/bin/`) is the primary touchpoint for transportation planners — keep it simple, with good `--help` text.
+- **Performance** matters most for model developers working at regional scale (Bay Area ~100k links, Twin Cities ~50k links).
+- **Validation errors** from Pandera should surface clearly, not as cryptic stack traces. Wrap them with context about which table/column failed.
+- **File format flexibility**: support geojson, parquet, and CSV, but recommend parquet for performance. Auto-detect format when possible.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,127 @@
+# Coding Conventions
+
+This page documents coding patterns and conventions specific to network_wrangler. For general setup and workflow, see [Contributing](development.md).
+
+## Python & Style
+
+- **Python 3.10+** with `from __future__ import annotations` for forward references
+- **Line length**: 99 characters (enforced by ruff)
+- **Docstrings**: Google-style (enforced by ruff `pydocstyle` convention)
+- **Type hints**: use throughout; PEP 604 union syntax (`X | None` not `Optional[X]`)
+- **Linting**: ruff (replaces flake8, black, isort)
+- **Type checking**: mypy (target Python 3.10, skip missing imports)
+- **Formatting**: `ruff format` with docstring code formatting enabled
+
+## Imports
+
+- Top-level imports preferred
+- **Lazy imports** allowed where needed to avoid circular dependencies (`PLC0415` is suppressed in ruff)
+- Common circular-dep patterns: `roadway.network` ↔ `roadway.model_roadway`, `transit.network` ↔ `roadway.network`
+
+## Pandas Patterns
+
+- **String dtype**: `pandas.options.future.infer_string` is set to `False` in `__init__.py` for pandera compatibility. Be aware when working with string columns — they use `object` dtype, not `StringDtype`.
+- **CI matrix**: code must work on both pandas 2.x and 3.x (Python 3.10 + pandas 3 is excluded)
+- **Prefer vectorized operations** over `.apply()` or row iteration
+- **Use `.loc[]` for assignment** to avoid `SettingWithCopyWarning`
+- **Categorical columns**: use for low-cardinality columns (e.g., mode, facility type) when performance matters
+- **Avoid chained indexing**: use `.loc[rows, cols]` not `df[col][rows]`
+
+## Validation Strategy
+
+Pandera validation and foreign key checks are expensive. Where and when to validate is a deliberate design choice driven by performance:
+
+### Pandera Schema Validation
+
+All DataFrame schemas are Pandera `DataFrameModel` subclasses in `network_wrangler/models/`:
+
+- `models/roadway/tables.py`: `RoadLinksTable`, `RoadNodesTable`, `RoadShapesTable`
+- `models/gtfs/tables.py`: GTFS feed table schemas (`WranglerStopsTable`, `WranglerStopTimesTable`, etc.)
+- `models/projects/`: schemas for project card change types
+
+**When to validate:**
+
+- **Reading from disk**: full schema validation on load (this is where bad data enters the system)
+- **Writing to disk**: full schema validation before write (guarantee output correctness)
+- **After project application**: validate only the columns/tables that the project actually touched — not the entire network
+- **Between internal functions**: do **not** run full pandera validation. Trust that data was validated at the boundary. If a specific internal function needs a precondition, use a lightweight assertion or check on just the relevant column, not a full `DataFrameModel.validate()` call.
+
+**Why**: Full pandera validation on a Bay Area-scale network (~100k links) can take seconds per call. Validating inside tight loops or between every internal function call can turn a sub-second edit into a multi-minute operation.
+
+**Patterns:**
+
+- Annotate DataFrames as `DataFrame[SchemaModel]` in function signatures for documentation, but don't rely on pandera's implicit validation in internal code paths
+- Schema coercion is enabled — pandera will attempt to cast types before failing
+- See `docs/data_models.md` for full schema reference
+
+### Foreign Key Consistency
+
+Foreign key relationships (e.g., link A_node/B_node referencing node model_node_id, or GTFS stop_times.trip_id referencing trips.trip_id) follow a similar boundary pattern:
+
+- **Guaranteed at IO boundaries**: foreign keys are validated when loading from disk and before writing to disk
+- **Guaranteed before and after each project application**: a project may temporarily break FK relationships during intermediate steps (e.g., adding links before adding their nodes), but FKs must be consistent when the project handler returns
+- **Not guaranteed within internal editing functions**: intermediate steps of a project handler may have dangling references. This is expected and acceptable — do not add FK checks inside handler helper functions.
+
+**Why**: FK validation requires joins across tables. Doing this after every small edit (add a link, delete a node, update a shape reference) multiplies the cost of project application.
+
+## GeoDataFrame / GeoPandas
+
+- Roadway links and nodes are stored as `GeoDataFrame` with geometry columns
+- Shapes are lazily loaded (`RoadwayNetwork.shapes_df` property)
+- CRS handling: networks store their CRS; transformations should preserve or explicitly convert
+- Use `gpd.GeoDataFrame` type hints, not plain `pd.DataFrame`, when geometry is required
+
+## Pydantic Models
+
+- `RoadwayNetwork` is a Pydantic `BaseModel` — use `model_config` for Pydantic settings, not class-level `Config`
+- `WranglerConfig` is Pydantic-based — override via YAML/TOML/JSON files
+- `ProjectCard` comes from the `projectcard` package — never reimplement card parsing
+
+## Scoped Properties
+
+A key domain concept. Link properties can be **scoped** by `category` (e.g., `sov`, `hov2`) and `timespan` (e.g., `["6:00", "9:00"]`):
+
+- Scoped values stored as lists of `ScopedLinkValueItem` on link records
+- Resolved at query time via `roadway/links/scopes.py::prop_for_scope()`
+- `ModelRoadwayNetwork` explodes scoped properties into flat columns: `{prop}_{timeperiod}_{category}` (e.g., `lanes_AM_sov`)
+- See `docs/design.md` for the resolution flowchart
+
+## Error Handling
+
+- Use custom exceptions from `network_wrangler/errors.py`
+- Error messages should be actionable — reference the specific project card, file, or field
+- Pandera validation errors should be wrapped with context (which table, which column)
+- See `USERS.md` for UX principles around error messages
+
+## Testing
+
+- **Framework**: pytest
+- **Markers**: `@pytest.mark.skipci` (skip in CI), `@pytest.mark.failing` (known failures)
+- **Fixtures**: session-scoped in `tests/conftest.py` for expensive setup (loading networks); module-level `conftest.py` in subdirectories
+- **Benchmarks**: `test_benchmarks.py` tracked via `pytest-benchmark`, compared across PRs
+- **Profiling**: `pytest-profiling` stores profiles in `.prof/`; explore with `snakeviz`
+- **Coverage**: only measured on Python 3.13 + pandas 3 in CI
+
+## Commits
+
+Use conventional commit format:
+
+- `fix:` — bug fix
+- `feat:` — new feature
+- `chore:` — maintenance, dependencies, CI
+- `docs:` — documentation only
+- `style:` — formatting, linting (no logic change)
+- `perf:` — performance improvement
+- `refactor:` — code change that neither fixes a bug nor adds a feature
+- `test:` — adding or updating tests
+
+## Diagram Maintenance
+
+When modifying code that changes module relationships, class hierarchies, or data flow, update the corresponding mermaid diagram in `docs/design.md` in the same PR. Current diagrams:
+
+- Ecosystem data flow
+- Core object model (class diagram)
+- Roadway selection & search (class diagram)
+- Project application flow (sequence diagram)
+- Scoped property resolution (flowchart)
+- IO pipeline (flowchart)

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,5 +1,136 @@
 # Design
 
+## Ecosystem Data Flow
+
+```mermaid
+flowchart LR
+    cube["Cube Model Files"] --> cw["cube_wrangler"]
+    cw --> cards["ProjectCards (.yml)"]
+    cards --> nw["network_wrangler"]
+    nw --> mcw["met_council_wrangler"]
+    mcw --> model["Cube-ready model network"]
+
+    pc["projectcard (schema)"] -.->|validates| cards
+    pc -.->|consumed by| nw
+    pc -.->|consumed by| cw
+```
+
+## Core Object Model
+
+```mermaid
+classDiagram
+    class Scenario {
+        +RoadwayNetwork road_net
+        +TransitNetwork transit_net
+        +dict project_cards
+        +list applied_projects
+        +WranglerConfig config
+        +apply_all_projects()
+        +add_project_cards(cards)
+        +queued_projects: list
+        +write(out_dir, file_format)
+    }
+
+    class RoadwayNetwork {
+        +DataFrame links_df
+        +DataFrame nodes_df
+        +DataFrame shapes_df
+        +WranglerConfig config
+        +str network_hash
+        +ModelRoadwayNetwork model_net
+        +apply(project_card)
+        +get_selection(selection_dict)
+        +add_links(links_df)
+        +delete_links(selection_dict)
+    }
+
+    class TransitNetwork {
+        +Feed feed
+        +RoadwayNetwork road_net
+        +WranglerConfig config
+        +apply(project_card)
+        +get_selection(selection_dict)
+        +bool consistent_with_road_net
+    }
+
+    class Feed {
+        +DataFrame stops
+        +DataFrame stop_times
+        +DataFrame routes
+        +DataFrame trips
+        +DataFrame shapes
+        +DataFrame frequencies
+        +set_by_id(table, set_df)
+    }
+
+    class ModelRoadwayNetwork {
+        +RoadwayNetwork net
+        +DataFrame links_df
+        +DataFrame nodes_df
+        +DataFrame ml_links_df
+        +DataFrame gp_links_df
+        +write(out_dir, file_format)
+    }
+
+    class ProjectCard {
+        <<from projectcard package>>
+        +str project
+        +list prerequisites
+        +list corequisites
+        +list conflicts
+        +dict change_types
+    }
+
+    Scenario o-- RoadwayNetwork
+    Scenario o-- TransitNetwork
+    Scenario o-- ProjectCard
+    TransitNetwork o-- Feed
+    TransitNetwork o-- RoadwayNetwork : optional
+    RoadwayNetwork --> ModelRoadwayNetwork : lazy creates
+    ModelRoadwayNetwork o-- RoadwayNetwork
+```
+
+## Roadway Selection & Search
+
+```mermaid
+classDiagram
+    class RoadwayLinkSelection {
+        +RoadwayNetwork net
+        +str selection_method
+        +list selected_links
+        +DataFrame selected_links_df
+        +Segment segment
+    }
+
+    class RoadwayNodeSelection {
+        +RoadwayNetwork net
+        +str selection_method
+        +list selected_nodes
+        +DataFrame selected_nodes_df
+    }
+
+    class Segment {
+        +RoadwayNetwork net
+        +RoadwayLinkSelection selection
+        +Subnet subnet
+        +list segment_nodes
+        +list segment_links
+        +connected_path_search()
+    }
+
+    class Subnet {
+        +RoadwayNetwork net
+        +MultiDiGraph graph
+        +DataFrame subnet_links_df
+        +list subnet_nodes
+    }
+
+    RoadwayNetwork --> RoadwayLinkSelection : cached in selections
+    RoadwayNetwork --> RoadwayNodeSelection : cached in selections
+    RoadwayLinkSelection o-- Segment : for segment selections
+    Segment o-- Subnet
+```
+
 ## Atomic Parts
 
 ```mermaid
@@ -13,7 +144,7 @@ flowchart TD
     BaseScenario --> base_scenario
     subgraph Scenario
     base_scenario["base_scenario(dict)"]
-    projects["projects(ProjectCard`"]
+    projects["projects(ProjectCard)"]
     road_net["road_net(RoadwayNetwork)"]
     transit_net["transit_net(TransitNetwork)"]
     config["config(WranglerConfig)"]
@@ -52,6 +183,35 @@ my_scenario.queued_projects
 my_scenario.apply_all_projects()
 my_scenario.applied_projects
 >> ["project_a", "project_b", "project_c"]
+```
+
+### Project Application Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Scenario
+    participant PC as ProjectCard
+    participant RN as RoadwayNetwork
+    participant TN as TransitNetwork
+    participant H as Handler (projects/)
+
+    U->>S: add_project_cards(cards)
+    S->>PC: validate & store
+    U->>S: apply_all_projects()
+    S->>S: order_projects() (topological sort)
+    loop For each queued project
+        S->>PC: get change type
+        alt roadway change
+            S->>RN: apply(project_card)
+            RN->>H: dispatch to handler
+            H->>RN: modify links_df/nodes_df
+        else transit change
+            S->>TN: apply(project_card)
+            TN->>H: dispatch to handler
+            H->>TN: modify feed tables
+        end
+    end
 ```
 
 ### Project Dependencies
@@ -182,6 +342,41 @@ Pertinent relationships:
 - `Subnet.graph` is the associated `networkx.MultiDiGraph` connected graph object which is used to conduct the shortest path search.
 
 For an interactive demonstration of what this means: `notebooks.Roadway Network Search.ipynb`
+
+## Scoped Property Resolution
+
+```mermaid
+flowchart TD
+    link["Link record with scoped properties"]
+    link --> check{"Is property scoped?"}
+    check -->|No| direct["Return direct value"]
+    check -->|Yes| scope_list["List of ScopedLinkValueItem"]
+    scope_list --> match{"Match category + timespan?"}
+    match -->|Found| resolved["Return scoped value"]
+    match -->|Not found| default["Return default/unscoped value"]
+    resolved --> model["ModelRoadwayNetwork explodes to flat columns"]
+    model --> flat["e.g. lanes_AM_sov, price_PM_hov2"]
+```
+
+Key function: `roadway/links/scopes.py::prop_for_scope()`
+
+## IO Pipeline
+
+```mermaid
+flowchart LR
+    subgraph Read
+        files["Files (geojson/parquet/csv)"] --> detect["Auto-detect format"]
+        detect --> load["load_roadway() / load_transit()"]
+        load --> validate["Pandera schema validation"]
+        validate --> df["DataFrame[RoadLinksTable] etc."]
+    end
+
+    subgraph Write
+        net["RoadwayNetwork / TransitNetwork"] --> write["write_roadway() / write_transit()"]
+        write --> fmt["Choose format (parquet preferred)"]
+        fmt --> out["Output files"]
+    end
+```
 
 ## Organization
 

--- a/network_wrangler/utils/models.py
+++ b/network_wrangler/utils/models.py
@@ -35,9 +35,7 @@ def _convert_string_dtype_to_object(df: DataFrame) -> DataFrame:
     df = df.copy()
     for col in df.columns:
         dtype = df[col].dtype
-        if isinstance(dtype, pd.StringDtype):
-            df[col] = df[col].astype(object)
-        elif isinstance(dtype, pd.ArrowDtype) and pa.types.is_string(dtype.pyarrow_dtype):
+        if isinstance(dtype, pd.StringDtype) or (isinstance(dtype, pd.ArrowDtype) and pa.types.is_string(dtype.pyarrow_dtype)):
             df[col] = df[col].astype(object)
     return df
 

--- a/skills/debugging-root-cause/SKILL.md
+++ b/skills/debugging-root-cause/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: debugging-root-cause
+description: Use whenever something is broken, failing, or behaving unexpectedly in network_wrangler — bugs, test failures, pandera/FK validation errors, "why is this not working", flaky tests, or surprising output. Use this even for seemingly simple fixes. Finds the actual root cause before proposing changes and prevents band-aid patches, suppressed exceptions, try/except-and-return-default fixes, or tests rewritten to match buggy behavior.
+---
+
+# Debugging: Root Cause First
+
+When something is broken, the goal is to **understand why** before fixing what. Band-aid fixes compound over time and create harder bugs later.
+
+## Required Steps
+
+### 1. Reproduce
+
+You cannot fix what you cannot reproduce. Before proposing any fix:
+
+- Write a minimal reproduction (smallest test, smallest input, fewest steps)
+- Confirm the bug is deterministic; if flaky, investigate the non-determinism *first* — it may be the actual root cause
+- If the bug only appears with a specific pandas version, note that; it may reveal a dtype or behavior assumption
+- If the bug is in a test, run it in isolation (`pytest tests/path/to/test.py::test_name -v`) to rule out test pollution
+
+### 2. Form a Hypothesis
+
+Don't start changing code until you can state:
+
+- What the code is *actually* doing
+- What it *should* be doing
+- Why the gap exists (not just where — why)
+
+"I think adding X will fix it" is not a hypothesis. "The scoped property resolver returns the default because the timespan comparison uses string equality instead of interval overlap" is a hypothesis.
+
+### 3. Narrow the Search Space
+
+- Binary search through recent commits (`git bisect`) when the bug is new
+- Isolate components: does it fail at IO, during project application, or at validation?
+- For pandera errors, inspect the actual DataFrame state just before validation — don't just read the error message
+- For FK consistency failures, check whether the violation is expected mid-project (see `docs/conventions.md` on validation boundaries)
+
+### 4. Fix the Cause, Not the Symptom
+
+**Red flags** that you're patching symptoms, not fixing the cause:
+
+- Catching an exception and returning a default
+- Adding an `if` check that bypasses the buggy path
+- Suppressing a warning without understanding what it indicated
+- Adding `pd.option_context` or pandera `validate=False` to "make tests pass"
+- Rewriting the test to match the current (buggy) behavior
+
+If you're tempted to do any of these, **stop** and explain in writing why the original path was wrong. The fix should address that explanation.
+
+### 5. Prove the Fix
+
+- Write (or update) a regression test that would have caught the bug
+- Run the full test suite — not just the failing test — to verify no new breakage
+- For performance bugs, include a benchmark (see `skills/performance-work/SKILL.md`)
+
+### 6. Document the Root Cause
+
+In the PR description or commit message, explain:
+
+- What the actual root cause was (not what you changed)
+- Why the previous code was wrong (design assumption that didn't hold, race condition, dtype mismatch, etc.)
+- Why the fix addresses that specific cause
+
+This is what distinguishes a `fix:` commit from a `chore:` commit. Future contributors reading `git blame` need the *why*.
+
+## Project-Specific Gotchas
+
+- **pandas 2 vs 3 string dtypes**: the `__init__.py` sets `future.infer_string = False` for pandera compat. Bugs involving string columns may behave differently if this is bypassed.
+- **Scoped properties**: if a property returns a wrong value, check `prop_for_scope()` and the list of `ScopedLinkValueItem` on the link, not just the direct column value.
+- **Validation boundaries**: pandera/FK failures in internal functions may indicate you're validating where you shouldn't — or that an earlier step left invalid state. See `docs/conventions.md`.
+- **Network hash caching**: `RoadwayNetwork` caches `model_net` keyed on `network_hash`. Stale derived objects after modification often mean the hash didn't invalidate.
+- **Ecosystem**: a bug in `cube_wrangler` or `met_council_wrangler` tests may actually be a network_wrangler API change. Check if the downstream repo pinned an old version.
+
+## When You're Stuck
+
+- Read the error message all the way through (including stack trace interior, not just the top line)
+- Check `docs/design.md` for architectural assumptions that may not match your mental model
+- Ask: "What would have to be true for this to happen?" then verify each assumption
+- Escalate to the user with specifics: what you've tried, what you've ruled out, what remains unknown

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: feature-design
+description: Use whenever adding new functionality, extending public APIs, adding project card change types, adding config options, changing DataFrame schemas, or making choices that affect how users or downstream repos (projectcard, cube_wrangler, met_council_wrangler) interact with network_wrangler. Use this before writing code for any new feature, even small ones — includes "how should I add X", "where does X belong", "new change type". Consults USERS.md personas and checks ecosystem impact before committing to an approach.
+---
+
+# Feature Design: Users First, Ecosystem Aware
+
+Network Wrangler is a library with multiple user personas and a downstream ecosystem. Design decisions ripple outward. Before writing code, think about who's affected and how.
+
+## Required Steps
+
+### 1. Read USERS.md
+
+Which persona(s) is this feature for?
+
+- **Transportation planners** — YAML project cards, CLI, error messages matter most
+- **Model developers** — Python API, performance, predictability matter most
+- **Tool developers** — stable public API, pandera schemas, extension points
+- **CI/automation** — deterministic, machine-readable, good exit codes
+
+A feature that helps one persona can harm another. Surface the tradeoff explicitly.
+
+### 2. Check Ecosystem Impact
+
+Will this change affect downstream repos? Check before committing to an approach:
+
+- **`projectcard`**: changes to project card schema, change types, or validation
+- **`cube_wrangler`**: changes to scoped-property logic, `prop_for_scope()`, public `roadway.links` / `transit.feed` APIs, or DataFrame schemas
+- **`met_council_wrangler`**: changes to `RoadwayNetwork` / `TransitNetwork` public interface, `WranglerConfig`, or project application behavior
+
+If affected: note it in the PR description, and ideally draft a companion PR in the downstream repo.
+
+### 3. Prefer Minimal Changes
+
+In order of preference:
+
+1. **Extend** existing abstractions with new optional behavior
+2. **Compose** — add a new module that uses existing APIs
+3. **Parameterize** — add a `WranglerConfig` option with a sensible default
+4. **Refactor** existing abstractions (last resort — this is where ecosystem breakage happens)
+
+Red flag: if your design requires changing a Pandera schema, a public function signature, or a `ProjectCard` change type, the blast radius is large. Consider whether the same goal can be met with a narrower change.
+
+### 4. Consider Defaults
+
+Defaults should serve the **common case** (single region, standard GTFS, reasonable performance settings). Uncommon needs should be reachable via config, not the default.
+
+- Does the default behavior match what a transportation planner would expect?
+- If the feature introduces a choice, what default minimizes surprise for existing users?
+- Can the default change be a `WranglerConfig` option with backwards compatibility?
+
+### 5. Design the Error Path
+
+Before writing the happy path, think about failures:
+
+- What can go wrong? (Bad input, missing data, schema mismatch, FK violation)
+- Where is the right place to detect it? (IO boundary? Project application?)
+- What's the error message? Include: what was expected, what was found, which record/file/field
+
+See `USERS.md` UX Principles — "Error messages should be actionable and reference the specific project card, data file, or field."
+
+### 6. Choose the Right Extension Point
+
+Network Wrangler has established extension points. Use them instead of creating new patterns:
+
+- **New project card change type**: add to `models/projects/`, add handler in `roadway/projects/` or `transit/projects/`, update `apply()` dispatch
+- **New IO format**: extend `roadway/io.py` or `transit/io.py` — format auto-detection is already there
+- **New config option**: extend `WranglerConfig` in `configs/wrangler.py`
+- **New validation**: add to the appropriate pandera schema in `models/`
+- **New selection type**: extend `RoadwaySelection` or `TransitSelection`
+
+If your feature doesn't fit an existing pattern, that's a signal — either you're introducing a genuinely new concept (document it in `docs/design.md`) or you're solving the wrong problem.
+
+### 7. Document the Design
+
+Before implementation is complete:
+
+- Add or update the relevant `docs/` page
+- Update the relevant mermaid diagram in `docs/design.md` (see `CONTRIBUTING.md` diagram convention)
+- If this is a new project card change type, document in `docs/networks.md` or `docs/how_to.md`
+- API changes appear automatically via mkdocstrings — but the design narrative doesn't
+
+## Project-Specific Considerations
+
+- **Scoped properties** are a core abstraction — extensions should use scoping rather than inventing parallel mechanisms
+- **Pandera schemas** are the data contract — schema changes are breaking changes for tool developers
+- **`ProjectCard` comes from `projectcard`** — never parse cards yourself; changes to card semantics go there first
+- **`WranglerConfig` is the right place** for tunable behavior — don't add ad-hoc globals or environment variables
+- **Lazy evaluation** is a pattern throughout (`shapes_df`, `model_net`, selections) — new derived objects should usually follow suit
+
+## Anti-Patterns
+
+- Adding a feature "just for Met Council" — region-specific logic belongs in `met_council_wrangler`
+- Adding Cube-specific output formats — belongs in `cube_wrangler`
+- Hardcoding time periods, vehicle categories, or area types — these are parameters, not constants
+- Creating parallel APIs (a new `load_roadway_v2()` alongside `load_roadway()`) — evolve the existing one with deprecation
+
+## When You're Unsure
+
+- Sketch the API surface (function signatures, project card YAML example, config keys) *before* implementing
+- Share the sketch with the user for feedback — cheap to revise at this stage
+- Check if a similar feature already exists that you could extend
+- Ask: "If I were a tool developer building on this, would I be surprised by this design?"

--- a/skills/performance-work/SKILL.md
+++ b/skills/performance-work/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: performance-work
+description: Use whenever performance, speed, memory, or validation overhead comes up in network_wrangler — optimizing code, profiling, benchmarking, "this is slow", "can we speed this up", reducing memory, or evaluating whether pandera validation is too expensive. Use this even when the fix seems obvious. Requires measurement before and after — no "this should be faster" claims. Applies to regional-scale networks (50k-100k links) where intuition about hotspots is often wrong.
+---
+
+# Performance Work: Measure, Don't Guess
+
+Performance claims without measurement are hypotheses, not improvements. This project runs on regional-scale networks (Twin Cities ~50k links, Bay Area ~100k links) where assumptions about what's slow are often wrong.
+
+## Required Steps
+
+### 1. Establish a Baseline
+
+Before changing anything:
+
+- Run the relevant benchmark in `tests/test_benchmarks.py` or write one
+- Save the baseline: `pytest --benchmark-save=before`
+- Note the dataset size (link/node/trip counts) — performance is not linear
+
+If there's no existing benchmark for what you're optimizing, **add one first**. Optimizations without benchmarks regress silently.
+
+### 2. Profile to Find the Actual Hotspot
+
+Assumed hotspots are usually wrong. Use tools:
+
+- **`pytest-profiling`** stores profiles in `.prof/` when tests run
+- **`snakeviz .prof/<test_name>.prof`** visualizes the call tree
+- **`cProfile`** for targeted profiling of a function
+
+Look for:
+
+- Unexpected time in pandera validation (see validation strategy below)
+- `apply()` / row iteration — almost always replaceable with vectorized ops
+- Repeated `network_hash` computation (should be cached)
+- `GeoDataFrame` operations that materialize geometry unnecessarily
+- Pandas operations that trigger `object` dtype fallback
+
+### 3. Respect the Validation Strategy
+
+Pandera validation is **expensive** — full validation of `RoadLinksTable` on a Bay Area network can take seconds. See `docs/conventions.md` for the full strategy. Summary:
+
+- **Validate at IO boundaries and at project boundaries** — not between internal functions
+- If profiling shows pandera hotspots inside tight loops or internal helpers, that's usually the bug
+- Foreign key validation is similar — guaranteed at IO and project boundaries, not intermediate steps
+- If you need a lightweight precondition check, assert on one column, don't call `SchemaModel.validate()`
+
+### 4. Optimize at the Right Level
+
+Order of impact (usually):
+
+1. **Algorithm** — O(n²) → O(n) beats any micro-optimization
+2. **Avoiding work** — caching, lazy evaluation, skipping validated data
+3. **Data structure** — categorical dtypes, sparse representations, appropriate indexes
+4. **Vectorization** — replacing `.apply()` with vectorized ops
+5. **Implementation** — faster library functions, avoiding copies
+
+Don't start at step 5.
+
+### 5. Measure Again
+
+After the change:
+
+- Run the same benchmark: `pytest --benchmark-save=after`
+- Compare: `pytest-benchmark compare before after`
+- Confirm the improvement on realistic data (not just tiny test fixtures)
+- Run the full test suite to verify no regressions
+
+### 6. Document the Measurement
+
+In the PR:
+
+- Include before/after numbers with dataset size
+- Name the bottleneck you addressed (e.g., "pandera validation called per-link in edit loop")
+- Note any tradeoffs (memory, code complexity, validation coverage)
+
+Use `perf:` as the commit prefix.
+
+## Project-Specific Patterns
+
+- **Scoped property access**: `prop_for_scope()` can be called many times per project application. If profiling shows it hot, consider batch resolution rather than per-link calls.
+- **`ModelRoadwayNetwork`**: lazily created and cached on `RoadwayNetwork.model_net`. Recomputing it is expensive — don't invalidate the cache unless the underlying network actually changed.
+- **Network hash**: `RoadwayNetwork.network_hash` is used for cache invalidation. Recomputing from scratch is O(links+nodes); excessive calls mean something is invalidating too eagerly.
+- **GeoDataFrame materialization**: operations that compute geometry on demand (e.g., `link_shapes_df`) can be costly. Cache when reused.
+- **GTFS table joins**: `stop_times` is the largest GTFS table. Operations that join it repeatedly are performance-critical; profile carefully.
+
+## Anti-Patterns to Watch For
+
+- "This feels slow, I'll add caching" — measure first, then cache the actual hotspot
+- "Let me disable validation here to speed it up" — validation costs are a *symptom*; the real fix is validating at the right boundary (see `docs/conventions.md`)
+- "I'll parallelize this" — usually a last resort after algorithm/vectorization wins. Adds complexity and debugging difficulty.
+- Optimizing code paths that aren't in the measured hotspot
+
+## When You're Unsure
+
+- Ask: "What's the expected time complexity of this operation? Does the measured time match?"
+- Share benchmark numbers with the user rather than describing performance qualitatively
+- Escalate tradeoffs (e.g., more memory for less CPU) rather than deciding silently


### PR DESCRIPTION
## Summary

- Adds tool-agnostic `AGENTS.md` (~400 tokens) so any AI coding assistant (Claude Code, Cursor, Copilot, Aider, Windsurf) gets consistent project context
- Adds `CLAUDE.md` as a thin Claude-specific delegate to `AGENTS.md`
- Adds `USERS.md` with 4 user personas (transportation planners, model developers, tool developers, CI/automation) and UX principles
- Adds `docs/conventions.md` covering coding style, validation strategy (when/where to run pandera and FK checks), pandas/pandera/geopandas patterns, testing, and commits
- Extends `docs/design.md` with 7 mermaid diagrams: ecosystem data flow, core object model, roadway selection, project application flow, scoped property resolution, IO pipeline
- Updates `CONTRIBUTING.md` with diagram maintenance convention and expanded testing section

Closes #458

## Design Decisions

- **Agent-agnostic**: all project knowledge in `AGENTS.md` + `docs/`. No tool-specific plugins committed to repo.
- **No duplication**: `AGENTS.md` is a concise index pointing to `docs/conventions.md`, `docs/design.md`, `CONTRIBUTING.md`, `USERS.md`. Details live in one place only.
- **Validation strategy**: documents when pandera/FK validation should and should not run (IO boundaries and project boundaries, not between internal functions) per performance requirements.
- **No nested AGENTS.md**: mermaid diagrams in `docs/design.md` replace the need for per-directory context files.

## Test plan

- [ ] Verify `mkdocs serve` renders new `docs/conventions.md` and mermaid diagrams in `docs/design.md` correctly
- [ ] Confirm no content duplication between `AGENTS.md` and `docs/conventions.md`
- [ ] Review persona descriptions in `USERS.md` for accuracy
- [ ] Check that mermaid class diagrams match actual class structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)