### PR TITLE
chore: bump ruff to 0.16.0 and resolve new lint findings

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -32,10 +32,10 @@ jobs:
       # (unpinned) grabs the latest release, so a new ruff can start failing
       # unchanged code the moment it's published. Keep both in sync.
       - name: Check formatting
-        run: uvx ruff@0.15.8 format --check network_wrangler
+        run: uvx ruff@0.16.0 format --check network_wrangler
 
       - name: Check linting
-        run: uvx ruff@0.15.8 check --output-format=github network_wrangler
+        run: uvx ruff@0.16.0 check --output-format=github network_wrangler
 
   test:
     name: Test (Python ${{ matrix.python-version }}, pandas ${{ matrix.pandas-version }})

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install ruff
         # Keep pinned in sync with .pre-commit-config.yaml and pullrequest.yml.
         run: |
-          uv pip install --system ruff==0.15.8
+          uv pip install --system ruff==0.16.0
         shell: bash
 
       - name: Check formatting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version - keep in sync with GitHub Actions
-    rev: v0.15.8
+    rev: v0.16.0
     hooks:
       # Run the linter.
       - id: ruff

--- a/network_wrangler/configs/utils.py
+++ b/network_wrangler/configs/utils.py
@@ -87,7 +87,7 @@ def find_configs_in_dir(dir: Path | list[Path], config_type) -> list[Path]:
     return []
 
 
-def _config_data_from_files(path: Path | list[Path] | None = None) -> None | dict:
+def _config_data_from_files(path: Path | list[Path] | None = None) -> dict | None:
     """Load and combine configuration data from file(s).
 
     Args:

--- a/network_wrangler/models/projects/roadway_changes.py
+++ b/network_wrangler/models/projects/roadway_changes.py
@@ -243,7 +243,7 @@ class RoadPropertyChange(RecordModel):
     existing: Any | None = None
     change: int | float | None = None
     set: Any | None = None
-    scoped: None | ScopedPropertySetList = None
+    scoped: ScopedPropertySetList | None = None
     overwrite_scoped: Literal["conflicting", "all", "error"] | None = None
     existing_value_conflict: Literal["error", "warn", "skip"] | None = None
 

--- a/network_wrangler/roadway/io.py
+++ b/network_wrangler/roadway/io.py
@@ -194,7 +194,7 @@ def load_roadway_from_dataframes(
 
 def id_roadway_file_paths_in_dir(
     dir: Path | str, file_format: RoadwayFileTypes = "geojson"
-) -> tuple[Path, Path, None | Path]:
+) -> tuple[Path, Path, Path | None]:
     """Identifies the paths to the links, nodes, and shapes files in a directory."""
     network_path = Path(dir)
     if not network_path.is_dir():

--- a/network_wrangler/roadway/links/create.py
+++ b/network_wrangler/roadway/links/create.py
@@ -71,7 +71,7 @@ def _fill_missing_distance_from_geometry(df: gpd.GeoDataFrame) -> gpd.GeoDataFra
 def data_to_links_df(
     links_df: pd.DataFrame | list[dict],
     in_crs: int = LAT_LON_CRS,
-    nodes_df: None | DataFrame[RoadNodesTable] = None,
+    nodes_df: DataFrame[RoadNodesTable] | None = None,
 ) -> DataFrame[RoadLinksTable]:
     """Create a links dataframe from list of link properties + link geometries or associated nodes.
 

--- a/network_wrangler/roadway/links/edit.py
+++ b/network_wrangler/roadway/links/edit.py
@@ -132,7 +132,7 @@ def _update_property_for_scope(
 
 @validate_call(config={"arbitrary_types_allowed": True}, validate_return=True)
 def _edit_scoped_link_property(
-    scoped_prop_value_list: None | list[ScopedLinkValueItem],
+    scoped_prop_value_list: list[ScopedLinkValueItem] | None,
     scoped_prop_set: ScopedPropertySetList,
     default_value: Any = None,
     overwrite_scoped: Literal["conflicting", "all", "error"] = "error",

--- a/network_wrangler/roadway/links/scopes.py
+++ b/network_wrangler/roadway/links/scopes.py
@@ -340,7 +340,7 @@ def _filter_exploded_df_to_scope(
 def prop_for_scope(
     links_df: pd.DataFrame,
     prop_name: str,
-    timespan: None | list[TimeString] = DEFAULT_TIMESPAN,
+    timespan: list[TimeString] | None = DEFAULT_TIMESPAN,
     category: str | int | None = DEFAULT_CATEGORY,
     strict_timespan_match: bool = False,
     min_overlap_minutes: int = 60,

--- a/network_wrangler/roadway/projects/edit_property.py
+++ b/network_wrangler/roadway/projects/edit_property.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 def _node_geo_change_from_property_changes(
     property_changes: dict[str, RoadPropertyChange],
     node_idx: list[int],
-) -> None | NodeGeometryChangeTable:
+) -> NodeGeometryChangeTable | None:
     """Return NodeGeometryChangeTable if property_changes includes gometry change else None."""
     geo_change_present = any(f in property_changes for f in ["X", "Y"])
     if not geo_change_present:

--- a/network_wrangler/roadway/selection.py
+++ b/network_wrangler/roadway/selection.py
@@ -221,8 +221,8 @@ class RoadwayLinkSelection(RoadwaySelection):
                 `SelectFacility` model with a "links" key or SelectFacility instance.
         """
         super().__init__(net, selection_data)
-        self._selected_links_df: None | DataFrame[RoadLinksTable] = None
-        self._segment: None | Segment = None
+        self._selected_links_df: DataFrame[RoadLinksTable] | None = None
+        self._segment: Segment | None = None
         WranglerLogger.debug(f"Created LinkSelection of type: {self.selection_method}")
 
     def __nonzero__(self) -> bool:
@@ -320,7 +320,7 @@ class RoadwayLinkSelection(RoadwaySelection):
         return self.selected_links_df is not None
 
     @property
-    def segment(self) -> None | Segment:
+    def segment(self) -> Segment | None:
         """Return the segment object if selection type is segment."""
         if self._segment is None and self.selection_method == "segment":
             WranglerLogger.debug("Creating new segment")
@@ -446,7 +446,7 @@ class RoadwayNodeSelection(RoadwaySelection):
                 conforming to SelectFacility format, or SelectFacility instance.
         """
         super().__init__(net, selection_data)
-        self._selected_nodes_df: None | DataFrame[RoadNodesTable] = None
+        self._selected_nodes_df: DataFrame[RoadNodesTable] | None = None
 
     def __nonzero__(self) -> bool:
         """Return True if nodes were selected."""

--- a/network_wrangler/transit/clip.py
+++ b/network_wrangler/transit/clip.py
@@ -234,12 +234,12 @@ def _clip_feed_to_nodes(
 
 def clip_transit(
     network: TransitNetwork | str | Path,
-    node_ids: None | list[str] = None,
-    boundary_geocode: None | str | dict = None,
+    node_ids: list[str] | None = None,
+    boundary_geocode: str | dict | None = None,
     boundary_file: str | Path | None = None,
-    boundary_gdf: None | gpd.GeoDataFrame = None,
-    ref_nodes_df: None | gpd.GeoDataFrame = None,
-    roadway_net: None | RoadwayNetwork = None,
+    boundary_gdf: gpd.GeoDataFrame | None = None,
+    ref_nodes_df: gpd.GeoDataFrame | None = None,
+    roadway_net: RoadwayNetwork | None = None,
     min_stops: int = DEFAULT_MIN_STOPS,
 ) -> TransitNetwork:
     """Returns a new TransitNetwork clipped to a boundary as determined by arguments.

--- a/network_wrangler/transit/network.py
+++ b/network_wrangler/transit/network.py
@@ -135,7 +135,7 @@ class TransitNetwork:
             raise TransitRoadwayConsistencyError(msg)
 
     @property
-    def road_net(self) -> None | RoadwayNetwork:
+    def road_net(self) -> RoadwayNetwork | None:
         """Roadway network associated with the transit network."""
         return self._road_net
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ ignore = [
     "PLC0415", # `import` should be at the top-level (intentional lazy imports to avoid circular deps)
     "C416", # non pep-604 annotations.
     "PLR0913", # too many args
+    "PLR0917", # too many positional args - same rationale as PLR0913; many public APIs take numerous optional keyword-defaulted params.
 ]
 extend-select = [
   "B",           # flake8-bugbear


### PR DESCRIPTION
Closes #485.

Moves CI + pre-commit off the stopgap `0.15.8` pin (from #482) to **0.16.0**, and resolves everything the newer ruff flags on `network_wrangler/`.

## What ruff 0.16.0 flagged (63 findings, 2 rules)

### RUF036 (17) — fixed for real ✅
`None` placed mid-union. Every one reordered `None | X` → `X | None`. Semantically identical, conventional ordering, **no `noqa`/suppressions**. Examples:

| File | Before → After |
|------|----------------|
| `transit/clip.py` | `node_ids: None \| list[str]` → `list[str] \| None` |
| `roadway/selection.py` | `self._segment: None \| Segment` → `Segment \| None` |
| `configs/utils.py` | `-> None \| dict` → `-> dict \| None` |
| `transit/network.py` | `road_net -> None \| RoadwayNetwork` → `RoadwayNetwork \| None` |

(13 more of the same shape — see the diff.)

### PLR0917 (46) — ignored in config, by design ⚙️
"Too many positional arguments (>5)." These are public entry points (`load_roadway` with 10 params, `clip_transit`, `clip_feed_to_boundary`, …) whose extra params are **optional and keyword-defaulted**. "Fixing" would mean forcing keyword-only args — a **breaking API change** requiring call-site/test churn and a version bump.

The sibling rule **`PLR0913`** ("too many arguments") is *already* ignored, so tolerating many-parameter functions is an established project decision. Added one documented line next to it:

```toml
"PLR0913", # too many args
"PLR0917", # too many positional args - same rationale as PLR0913; many public APIs take numerous optional keyword-defaulted params.
```

> **Reviewer note:** this is the only suppression in the PR. If you'd rather make these signatures keyword-only instead, that's a separate, larger, breaking-change PR — happy to do it that way.

## Version bump (kept in sync)
- `.pre-commit-config.yaml`: `v0.15.8` → `v0.16.0`
- `.github/workflows/pullrequest.yml`: `uvx ruff@0.15.8` → `@0.16.0`
- `.github/workflows/push.yml`: `ruff==0.15.8` → `==0.16.0`

## Verification
- `uvx ruff@0.16.0 format --check network_wrangler` → 125 files already formatted
- `uvx ruff@0.16.0 check network_wrangler` → **All checks passed**
- All 10 edited modules import cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)